### PR TITLE
Minor SwerveWithPathPlanner example improvements

### DIFF
--- a/java/SwerveWithPathPlanner/src/main/java/frc/robot/CommandSwerveDrivetrain.java
+++ b/java/SwerveWithPathPlanner/src/main/java/frc/robot/CommandSwerveDrivetrain.java
@@ -53,10 +53,9 @@ public class CommandSwerveDrivetrain extends SwerveDrivetrain implements Subsyst
             (speeds)->this.setControl(autoRequest.withSpeeds(speeds)), // Consumer of ChassisSpeeds to drive the robot
             new HolonomicPathFollowerConfig(new PIDConstants(10, 0, 0),
                                             new PIDConstants(10, 0, 0),
-                                            1,
-                                            1,
-                                            new ReplanningConfig(),
-                                            0.004),
+                                            1, // TODO: Max module speed. Adjust this for your specific robot
+                                            1, // TODO: Distance from center of robot to furthest module. Adjust this for your specific robot
+                                            new ReplanningConfig()),
             this); // Subsystem for requirements
     }
 


### PR DESCRIPTION
Fixes a minor issue with the example as well as adds a couple comments to hopefully avoid confusion

* Removes the set loop time of 0.004s. This should be the period at which the command scheduler is run, which does not appear to be changed in this example.
* Adds TODO comments to the max module speed and drive base radius config fields to make it more clear that these need to be changed. If left at 1, the robot would pretty much never rotate.