### PR TITLE
Adds resource lock to all unit tests

### DIFF
--- a/java/BasicLatencyCompensation/src/test/java/LatencyCompensationTests.java
+++ b/java/BasicLatencyCompensation/src/test/java/LatencyCompensationTests.java
@@ -16,7 +16,10 @@ import edu.wpi.first.units.measure.Time;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
+@ResourceLock(value = "SimState", mode = ResourceAccessMode.READ_WRITE)
 public class LatencyCompensationTests {
     final double DOUBLE_DELTA = 0.01;
 

--- a/java/ControlRequestLimits/src/test/java/LimitTests.java
+++ b/java/ControlRequestLimits/src/test/java/LimitTests.java
@@ -19,7 +19,10 @@ import edu.wpi.first.wpilibj.simulation.DriverStationSim;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
+@ResourceLock(value = "SimState", mode = ResourceAccessMode.READ_WRITE)
 public class LimitTests {
     final double SET_DELTA = 0.01;
     final int CONFIG_RETRY_COUNT = 5;

--- a/java/CurrentLimits/src/test/java/CurrentLimitTests.java
+++ b/java/CurrentLimits/src/test/java/CurrentLimitTests.java
@@ -17,7 +17,10 @@ import edu.wpi.first.wpilibj.simulation.DriverStationSim;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
+@ResourceLock(value = "SimState", mode = ResourceAccessMode.READ_WRITE)
 public class CurrentLimitTests implements AutoCloseable {
     final int CONFIG_RETRY_COUNT = 5;
 

--- a/java/FusedCANcoder/src/test/java/FusedCANcoderTests.java
+++ b/java/FusedCANcoder/src/test/java/FusedCANcoderTests.java
@@ -16,7 +16,10 @@ import edu.wpi.first.units.measure.Angle;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
+@ResourceLock(value = "SimState", mode = ResourceAccessMode.READ_WRITE)
 public class FusedCANcoderTests {
     final double SET_DELTA = 0.1;
     final int CONFIG_RETRY_COUNT = 5;

--- a/java/Pigeon2/src/test/java/Pigeon2Tests.java
+++ b/java/Pigeon2/src/test/java/Pigeon2Tests.java
@@ -11,7 +11,10 @@ import edu.wpi.first.wpilibj.Timer;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
+@ResourceLock(value = "SimState", mode = ResourceAccessMode.READ_WRITE)
 public class Pigeon2Tests {
     final double SET_DELTA = 0.1;
     final int CONFIG_RETRY_COUNT = 5;


### PR DESCRIPTION
Our tests all rely on the same SimState resource. Accessing/Modifying the sim state resource while another test is running will likely result in the test failing. Putting a resource lock around the test class ensures all tests are run sequentially to prevent simultaneous access and reduce the liklihood of erroneous failures