### PR TITLE
Added nonFRC examples

### DIFF
--- a/python/CANcoder_nonFRC/main.py
+++ b/python/CANcoder_nonFRC/main.py
@@ -1,0 +1,18 @@
+import time
+from phoenix6.hardware import CANcoder
+
+# Initialize the CANcoder with the appropriate device ID
+DEVICE_ID = 1  # Replace with your actual device ID
+CAN_INTERFACE = 'can0'
+
+cancoder = CANcoder(DEVICE_ID, CAN_INTERFACE)
+
+try:
+    while True:
+
+        position = cancoder.get_absolute_position().value
+        print(f"Absolute Position: {position:.4f} rotations")
+        time.sleep(0.1)
+        
+except KeyboardInterrupt:
+    print("Stopped reading CANcoder.")

--- a/python/TalonFX_nonFRC/main.py
+++ b/python/TalonFX_nonFRC/main.py
@@ -1,0 +1,46 @@
+import time
+from phoenix6 import hardware, controls, unmanaged
+
+def main():
+    # Create a TalonFX motor controller on CAN ID 2
+    motor = hardware.TalonFX(2, "can0")
+    
+    # Create a duty cycle control request
+    duty_cycle = controls.DutyCycleOut(0)
+    
+    print("Starting motor ramp test...")
+    
+    # Enable the motor
+    unmanaged.feed_enable(100)
+    
+    # Ramp up from 0 to 1
+    for i in range(0, 11):
+        duty_cycle.output = i / 10.0
+        motor.set_control(duty_cycle)
+        unmanaged.feed_enable(100)  # Keep feeding the enable
+        print(f"Duty Cycle: {i/10.0}")
+        time.sleep(0.5)
+    
+    # Ramp down from 1 to -1
+    for i in range(10, -11, -1):
+        duty_cycle.output = i / 10.0
+        motor.set_control(duty_cycle)
+        unmanaged.feed_enable(100)  # Keep feeding the enable
+        print(f"Duty Cycle: {i/10.0}")
+        time.sleep(0.5)
+    
+    # Ramp up from -1 to 0
+    for i in range(-10, 1):
+        duty_cycle.output = i / 10.0
+        motor.set_control(duty_cycle)
+        unmanaged.feed_enable(100)  # Keep feeding the enable
+        print(f"Duty Cycle: {i/10.0}")
+        time.sleep(0.5)
+    
+    # Stop the motor
+    motor.set_control(controls.NeutralOut())
+    unmanaged.feed_enable(100)  # Final feed
+    print("Test complete")
+
+if __name__ == "__main__":
+    main() 


### PR DESCRIPTION
Added non-FRC use case examples for the TalonFX motor control and CANcoder in python.